### PR TITLE
Clarify which DNSSEC version we are referring to

### DIFF
--- a/draft-ietf-dnsop-dnssec-bcp.mkd
+++ b/draft-ietf-dnsop-dnssec-bcp.mkd
@@ -122,7 +122,7 @@ RFCs should also include looking for the related errata.
 What we today call "DNSSEC" is formally version 3 of the DNSSEC specification.
 However, earlier versions of DNSSEC were thinly deployed and significantly less
 visible than the current DNSSEC specification. Throughout this document, "DNSSEC"
-means the version of the protocol initially defined in {{RFC4033}}, {{RFC4034}}, and {{RFC4035}}.
+means version 3 of the protocol initially defined in {{RFC4033}}, {{RFC4034}}, and {{RFC4035}}.
 
 The three initial core documents generally cover different topics:
 


### PR DESCRIPTION
The current text can be interpreted incorrectly. It essentially says "_DNSSEC is formally version 3 .... however, earlier versions of DNSSEC were ... significantly less visible ... Here DNSSEC means the version of the protocol initially defined in ..._" 

The use of the word "_initially_" in the last sentence, in conjunction with some low-numbered RFC numbers, can lead the reader to think that you are referring to version 1.

This PR aims to make it clearer that we are pointing to version 3.